### PR TITLE
Add missing frontend path in albfront stage

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -877,7 +877,7 @@ class PipelineStack(Stack):
                         'pip install beautifulsoup4',
                         'python deploy/configs/frontend_config.py',
                         'unset AWS_PROFILE',
-                        f'docker build -f docker/prod/Dockerfile --build-arg REACT_APP_STAGE={target_env["envname"]} --build-arg DOMAIN={target_env.get("custom_domain", {}).get("name")} -t $IMAGE_TAG:$IMAGE_TAG .',
+                        f'docker build -f frontend/docker/prod/Dockerfile --build-arg REACT_APP_STAGE={target_env["envname"]} --build-arg DOMAIN={target_env.get("custom_domain", {}).get("name")} -t $IMAGE_TAG:$IMAGE_TAG .',
                         f'aws ecr get-login-password --region {self.region} | docker login --username AWS --password-stdin {self.account}.dkr.ecr.{self.region}.amazonaws.com',
                         'docker tag $IMAGE_TAG:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG',
                         'docker push $REPOSITORY_URI:$IMAGE_TAG',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Added missing 'frontend' path in albfront stage. In modularization the command to create the docker images has changes in codebuild and we do not `cd` into the `frontend` directory. 

### Relates
- v2.0.0 validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
